### PR TITLE
Fix: undefined dimension referenced in google_ads__monthly_number_of_ads_by_account model

### DIFF
--- a/models/metrics/count_of_ads_metrics/google_ads__monthly_number_of_ads_by_account.sql
+++ b/models/metrics/count_of_ads_metrics/google_ads__monthly_number_of_ads_by_account.sql
@@ -6,6 +6,6 @@ select *
 from {{ metrics.calculate(
   metric('google_ads__monthly_number_of_ads_by_account'),
   grain = 'month',
-  dimensions = ['ad_group_name'],
+  dimensions = ['account_name'],
   secondary_calculations = []
 ) }}


### PR DESCRIPTION
Metric model is referencing undefined dimension, possibly typo